### PR TITLE
fix: perform interpolation of allele frequency distribution on the probability scale instead of PHRED scale; further, this changes AF distribution display to a bubble chart

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -40,18 +40,21 @@ pub struct VariantID(#[deref] pub i32);
 pub struct Haplotype(#[deref] pub String);
 
 #[derive(Debug, Clone, Derefable)]
-pub struct AlleleFreqDist(#[deref] BTreeMap<AlleleFreq, f64>);
+pub struct AlleleFreqDist(#[deref] BTreeMap<AlleleFreq, LogProb>);
 
 impl AlleleFreqDist {
     pub fn vaf_query(&self, vaf: &AlleleFreq) -> Option<LogProb> {
         if self.contains_key(&vaf) {
-            Some(LogProb::from(PHREDProb(*self.get(&vaf).unwrap())))
+            Some(*self.get(&vaf).unwrap())
         } else {
-            let (x_0, y_0) = self.range(..vaf).next_back().unwrap();
-            let (x_1, y_1) = self.range(vaf..).next().unwrap();
+            let (x_0, mut y_0) = self.range(..vaf).next_back().unwrap();
+            let (x_1, mut y_1) = self.range(vaf..).next().unwrap();
+            // TODO check: linear interpolation on what scale? Before it was on the PHRED scale. I think it should be on the normal probability scale instead.
+            y_0 = y_0.exp();
+            y_1 = y_1.exp();
             let density =
                 NotNan::new(*y_0).unwrap() + (*vaf - *x_0) * (*y_1 - *y_0) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
-            Some(LogProb::from(PHREDProb(NotNan::into_inner(density))))
+            Some(LogProb::from(Prob(density)))
         }
     }
 }
@@ -124,7 +127,7 @@ impl VariantCalls {
                     if let Some((vaf, density)) = pair.split_once("=") {
                         let (vaf, density): (AlleleFreq, f64) =
                             (vaf.parse().unwrap(), density.parse().unwrap());
-                        vaf_density.insert(vaf, density);
+                        vaf_density.insert(vaf, LogProb::from(PHREDProb(density)));
                     }
                 }
                 calls.insert(VariantID(variant_id), (af, AlleleFreqDist(vaf_density)));
@@ -484,7 +487,7 @@ pub fn plot_prediction(
                                 plot_data_dataset_afd.push(DatasetAfd {
                                     variant: *variant_id,
                                     allele_freq: *allele_freq,
-                                    probability: prob.clone(),
+                                    probability: Prob::from(prob),
                                 })
                             }
                         }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -54,7 +54,12 @@ impl AlleleFreqDist {
             let y_1_prob = y_1.exp();
             let density =
                 NotNan::new(y_0_prob).unwrap() + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
-            Some(LogProb::from(Prob(NotNan::into_inner(density))))
+                //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
+                if density == NotNan::new(0.0).unwrap(){
+                    Some(LogProb::ln_one())
+                } else {
+                    Some(LogProb::from(Prob(NotNan::into_inner(density))))
+                }
         }
     }
 }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -49,7 +49,7 @@ impl AlleleFreqDist {
         } else {
             let (x_0, mut y_0) = self.range(..vaf).next_back().unwrap();
             let (x_1, mut y_1) = self.range(vaf..).next().unwrap();
-            // TODO check: linear interpolation on what scale? Before it was on the PHRED scale. I think it should be on the normal probability scale instead.
+            // METHOD: we perform linear interpolation on the plain probability scale
             y_0 = y_0.exp();
             y_1 = y_1.exp();
             let density =

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -52,14 +52,14 @@ impl AlleleFreqDist {
             // METHOD: we perform linear interpolation on the plain probability scale
             let y_0_prob = y_0.exp();
             let y_1_prob = y_1.exp();
-            let density =
-                NotNan::new(y_0_prob).unwrap() + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
-                //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
-                if density == NotNan::new(0.0).unwrap(){
-                    Some(LogProb::ln_one())
-                } else {
-                    Some(LogProb::from(Prob(NotNan::into_inner(density))))
-                }
+            let density = NotNan::new(y_0_prob).unwrap()
+                + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
+                                                                         //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
+            if density == NotNan::new(0.0).unwrap() {
+                Some(LogProb::ln_one())
+            } else {
+                Some(LogProb::from(Prob(NotNan::into_inner(density))))
+            }
         }
     }
 }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -47,14 +47,14 @@ impl AlleleFreqDist {
         if self.contains_key(&vaf) {
             Some(*self.get(&vaf).unwrap())
         } else {
-            let (x_0, mut y_0) = self.range(..vaf).next_back().unwrap();
-            let (x_1, mut y_1) = self.range(vaf..).next().unwrap();
+            let (x_0, y_0) = self.range(..vaf).next_back().unwrap();
+            let (x_1, y_1) = self.range(vaf..).next().unwrap();
             // METHOD: we perform linear interpolation on the plain probability scale
-            y_0 = y_0.exp();
-            y_1 = y_1.exp();
+            let y_0_prob = y_0.exp();
+            let y_1_prob = y_1.exp();
             let density =
-                NotNan::new(*y_0).unwrap() + (*vaf - *x_0) * (*y_1 - *y_0) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
-            Some(LogProb::from(Prob(density)))
+                NotNan::new(y_0_prob).unwrap() + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
+            Some(LogProb::from(Prob(NotNan::into_inner(density))))
         }
     }
 }
@@ -487,7 +487,7 @@ pub fn plot_prediction(
                                 plot_data_dataset_afd.push(DatasetAfd {
                                     variant: *variant_id,
                                     allele_freq: *allele_freq,
-                                    probability: Prob::from(prob),
+                                    probability: f64::from(*prob),
                                 })
                             }
                         }

--- a/templates/prediction.json
+++ b/templates/prediction.json
@@ -82,7 +82,7 @@
   },
   {
     "data": {"name": "allele_frequency_distribution"},
-    "mark": {"type": "rect", "tooltip": true},
+    "mark": {"type": "circle", "tooltip": true},
     "encoding": {
       "x": {
         "field": "variant",
@@ -92,11 +92,18 @@
       },
       "y": {
         "field": "allele_freq",
-        "type": "ordinal",
+        "type": "quantitative",
         "title": "Allele frequency",
         "axis": {"labelFontSize": 12, "titleFontSize": 16}
       },
       "color": {
+        "field": "probability",
+        "type": "quantitative",
+        "legend": {
+          "title": null
+        }
+      },
+      "size": {
         "field": "probability",
         "type": "quantitative",
         "legend": {


### PR DESCRIPTION
Before, we did it on the PHRED scale which could have unexpected effects.