### PR TITLE
fix: implement user defined parameters threshold for equivalence classes and extending haplotype list; also properly adjust path of equivalence class graph

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -290,11 +290,8 @@ impl HaplotypeVariants {
     pub fn find_equivalence_class(
         &self,
         application: &str,
+        threshold: usize //an edge in the graph representation for the equivalence classes is drawn if and only if the distance in terms of variants is smaller than a given threshold and the two nodes belong to the same group
     ) -> Result<Graph<(Haplotype, Haplotype), i32, petgraph::Undirected>> {
-        //an edge in the graph representation for the equivalence classes is drawn if and only
-        //if the distance in terms of variants is smaller than a given threshold and the two nodes belong to the same group
-        let threshold = 1; //should be configured.
-
         // BTreeMap<VariantID, BTreeMap<Haplotype, (VariantStatus, bool)>>
         let mut equivalence_classes: BTreeMap<Haplotype, Vec<VariantID>> = BTreeMap::new();
 

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -290,7 +290,8 @@ impl HaplotypeVariants {
     pub fn find_equivalence_class(
         &self,
         application: &str,
-        threshold: usize //an edge in the graph representation for the equivalence classes is drawn if and only if the distance in terms of variants is smaller than a given threshold and the two nodes belong to the same group
+        threshold: usize, //an edge in the graph representation for the equivalence classes is drawn if and only if the distance in terms of variants is smaller than a given threshold and the two nodes belong to the same group
+        output_graph: &PathBuf,
     ) -> Result<Graph<(Haplotype, Haplotype), i32, petgraph::Undirected>> {
         // BTreeMap<VariantID, BTreeMap<Haplotype, (VariantStatus, bool)>>
         let mut equivalence_classes: BTreeMap<Haplotype, Vec<VariantID>> = BTreeMap::new();
@@ -367,9 +368,15 @@ impl HaplotypeVariants {
             }
         }
         dbg!(&deps);
-        let mut f = File::create("example.dot").unwrap();
+
+        //create file path  for the graph
+        let mut parent = output_graph.clone();
+        parent.pop();
+        let mut file = fs::File::create(parent.join("graph.dot")).unwrap();
+
+        //write graph to path
         let output = format!("{:?}", Dot::with_config(&deps, &[Config::EdgeNoLabel]));
-        f.write_all(&output.as_bytes())
+        file.write_all(&output.as_bytes())
             .expect("could not write file");
 
         //todo: implement virus case.

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -37,6 +37,8 @@ pub struct Caller {
     common_variants: bool,
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
+    threshold_equivalence_class: usize,
+    num_extend_haplotypes: i64
 }
 
 impl Caller {
@@ -96,9 +98,6 @@ impl Caller {
             //find the haplotypes to prioritize
             let candidate_matrix = CandidateMatrix::new(&filtered_haplotype_variants).unwrap();
 
-            //currently, ideal variant distance used for extension is 3 for hla typing.
-            let num_variant_distance: i64 = 3;
-
             //employ the linear program
             let lp_haplotypes = haplotypes::linear_program(
                 &self.outcsv,
@@ -106,7 +105,7 @@ impl Caller {
                 &haplotypes,
                 &variant_calls,
                 self.lp_cutoff,
-                num_variant_distance,
+                self.num_extend_haplotypes,
             )?;
             dbg!(&lp_haplotypes);
 
@@ -125,7 +124,7 @@ impl Caller {
 
             //
             let eq_graph = filtered_haplotype_variants
-                .find_equivalence_class("hla")
+                .find_equivalence_class("hla", self.threshold_equivalence_class)
                 .unwrap();
             dbg!(&eq_graph);
 

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -38,7 +38,7 @@ pub struct Caller {
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
     threshold_equivalence_class: usize,
-    num_extend_haplotypes: i64
+    num_extend_haplotypes: i64,
 }
 
 impl Caller {
@@ -124,7 +124,11 @@ impl Caller {
 
             //
             let eq_graph = filtered_haplotype_variants
-                .find_equivalence_class("hla", self.threshold_equivalence_class)
+                .find_equivalence_class(
+                    "hla",
+                    self.threshold_equivalence_class,
+                    &self.outcsv.clone(),
+                )
                 .unwrap();
             dbg!(&eq_graph);
 

--- a/src/calling/haplotypes/virus.rs
+++ b/src/calling/haplotypes/virus.rs
@@ -28,6 +28,8 @@ pub struct Caller {
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
     threshold_considered_variants: f64,
+    threshold_equivalence_class: usize,
+    num_extend_haplotypes: i64
 }
 
 impl Caller {
@@ -71,9 +73,6 @@ impl Caller {
                 //find the haplotypes to prioritize
                 let candidate_matrix = CandidateMatrix::new(&filtered_haplotype_variants).unwrap();
 
-                //currently, ideal variant distance used for extension is 0 for viruses.
-                let num_variant_distance: i64 = 1;
-
                 //employ the lineaar program
                 let lp_haplotypes = haplotypes::linear_program(
                     &self.outcsv,
@@ -81,7 +80,7 @@ impl Caller {
                     &haplotypes,
                     &variant_calls,
                     self.lp_cutoff,
-                    num_variant_distance,
+                    self.num_extend_haplotypes,
                 )?;
                 dbg!(&lp_haplotypes);
 
@@ -100,7 +99,7 @@ impl Caller {
 
                 //
                 let eq_graph = lp_haplotype_variants
-                    .find_equivalence_class("virus")
+                    .find_equivalence_class("virus", self.threshold_equivalence_class)
                     .unwrap();
                 dbg!(&eq_graph);
 

--- a/src/calling/haplotypes/virus.rs
+++ b/src/calling/haplotypes/virus.rs
@@ -29,7 +29,7 @@ pub struct Caller {
     enable_equivalence_class_constraint: bool,
     threshold_considered_variants: f64,
     threshold_equivalence_class: usize,
-    num_extend_haplotypes: i64
+    num_extend_haplotypes: i64,
 }
 
 impl Caller {
@@ -99,7 +99,11 @@ impl Caller {
 
                 //
                 let eq_graph = lp_haplotype_variants
-                    .find_equivalence_class("virus", self.threshold_equivalence_class)
+                    .find_equivalence_class(
+                        "virus",
+                        self.threshold_equivalence_class,
+                        &self.outcsv.clone(),
+                    )
                     .unwrap();
                 dbg!(&eq_graph);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -230,11 +230,13 @@ pub enum CallKind {
         )]
         enable_equivalence_class_constraint: bool,
         #[structopt(
+            long,
             default_value = "1",
             help = "Threshold for assigning equivalence classes."
         )]
         threshold_equivalence_class: usize,
         #[structopt(
+            long,
             default_value = "3",
             help = "Number of variant distances to extend haplotype list coming from the linear program."
         )]
@@ -274,11 +276,13 @@ pub enum CallKind {
         )]
         threshold_considered_variants: f64,
         #[structopt(
+            long,
             default_value = "2",
             help = "Threshold for assigning equivalence classes."
         )]
         threshold_equivalence_class: usize,
         #[structopt(
+            long,
             default_value = "0",
             help = "Number of variant distances to extend haplotype list coming from the linear program."
         )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -229,6 +229,16 @@ pub enum CallKind {
             help = "Enable equivalence based constrain during model exploration."
         )]
         enable_equivalence_class_constraint: bool,
+        #[structopt(
+            default_value = "1",
+            help = "Threshold for assigning equivalence classes."
+        )]
+        threshold_equivalence_class: usize,
+        #[structopt(
+            default_value = "3",
+            help = "Number of variant distances to extend haplotype list coming from the linear program."
+        )]
+        num_extend_haplotypes: i64
     },
     Virus {
         #[structopt(
@@ -263,6 +273,16 @@ pub enum CallKind {
             help = "Percent threshold for evaluated variants."
         )]
         threshold_considered_variants: f64,
+        #[structopt(
+            default_value = "2",
+            help = "Threshold for assigning equivalence classes."
+        )]
+        threshold_equivalence_class: usize,
+        #[structopt(
+            default_value = "0",
+            help = "Number of variant distances to extend haplotype list coming from the linear program."
+        )]
+        num_extend_haplotypes: i64
     },
 }
 
@@ -350,6 +370,8 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 common_variants,
                 lp_cutoff,
                 enable_equivalence_class_constraint,
+                threshold_equivalence_class,
+                num_extend_haplotypes
             } => {
                 let mut caller = calling::haplotypes::hla::CallerBuilder::default()
                     .haplotype_variants(bcf::Reader::from_path(haplotype_variants)?)
@@ -362,6 +384,8 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .common_variants(common_variants)
                     .lp_cutoff(lp_cutoff)
                     .enable_equivalence_class_constraint(enable_equivalence_class_constraint)
+                    .threshold_equivalence_class(threshold_equivalence_class)
+                    .num_extend_haplotypes(num_extend_haplotypes)
                     .build()
                     .unwrap();
                 caller.call()?;
@@ -374,7 +398,9 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 prior,
                 lp_cutoff,
                 enable_equivalence_class_constraint,
+                threshold_equivalence_class,
                 threshold_considered_variants,
+                num_extend_haplotypes
             } => {
                 let mut caller = calling::haplotypes::virus::CallerBuilder::default()
                     .candidates_folder(candidates_folder)
@@ -383,7 +409,9 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .prior(prior)
                     .lp_cutoff(lp_cutoff)
                     .enable_equivalence_class_constraint(enable_equivalence_class_constraint)
+                    .threshold_equivalence_class(threshold_equivalence_class)
                     .threshold_considered_variants(threshold_considered_variants)
+                    .num_extend_haplotypes(num_extend_haplotypes)
                     .build()
                     .unwrap();
                 caller.call()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,7 +238,7 @@ pub enum CallKind {
             default_value = "3",
             help = "Number of variant distances to extend haplotype list coming from the linear program."
         )]
-        num_extend_haplotypes: i64
+        num_extend_haplotypes: i64,
     },
     Virus {
         #[structopt(
@@ -282,7 +282,7 @@ pub enum CallKind {
             default_value = "0",
             help = "Number of variant distances to extend haplotype list coming from the linear program."
         )]
-        num_extend_haplotypes: i64
+        num_extend_haplotypes: i64,
     },
 }
 
@@ -371,7 +371,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 lp_cutoff,
                 enable_equivalence_class_constraint,
                 threshold_equivalence_class,
-                num_extend_haplotypes
+                num_extend_haplotypes,
             } => {
                 let mut caller = calling::haplotypes::hla::CallerBuilder::default()
                     .haplotype_variants(bcf::Reader::from_path(haplotype_variants)?)
@@ -400,7 +400,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 enable_equivalence_class_constraint,
                 threshold_equivalence_class,
                 threshold_considered_variants,
-                num_extend_haplotypes
+                num_extend_haplotypes,
             } => {
                 let mut caller = calling::haplotypes::virus::CallerBuilder::default()
                     .candidates_folder(candidates_folder)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,6 +15,8 @@ fn check_haplotype_fractions_5050() {
         .outcsv(output)
         .prior("diploid".to_string())
         .lp_cutoff(0.01)
+        .threshold_equivalence_class(1)
+        .num_extend_haplotypes(3)
         .build()
         .unwrap()
         .call();


### PR DESCRIPTION
Before threshold for equivalence classes and number of variant distance used to extend haplotype list coming from linear program was hardcoded. This PR implements them as parameters. 
In addition, this now adjusts the file path of the graph output of equivalence classes.