### PR TITLE
fix: fix equivalence class generation for hla and virus case separately; further, implement a flag for extension of haplotype list after linear program computation

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -126,7 +126,6 @@ impl VariantCalls {
                 //because some afd strings are just "." and that throws an error while splitting below.
                 let variant_id: i32 = String::from_utf8(record.id())?.parse().unwrap();
                 let af = (&*record.format(b"AF").float().unwrap()[0]).to_vec()[0];
-                //dbg!(&af);
                 let mut vaf_density = BTreeMap::new();
                 for pair in afd.split(',') {
                     if let Some((vaf, density)) = pair.split_once("=") {
@@ -156,14 +155,10 @@ impl VariantCalls {
     ) -> Result<bool> {
         let variants_haplotype_variants: Vec<_> = haplotype_variants.keys().cloned().collect();
         let variants_haplotype_calls: Vec<_> = self.keys().cloned().collect();
-        // dbg!(&variants_haplotype_variants);
-        // dbg!(&variants_haplotype_variants.len());
-        // dbg!(&variants_haplotype_calls);
-        // dbg!(&variants_haplotype_calls.len());
+
         let rateof_evaluated_haplotypes: f64 =
             variants_haplotype_calls.len() as f64 / variants_haplotype_variants.len() as f64;
-        // dbg!(&rateof_evaluated_haplotypes);
-        // dbg!(&threshold_considered_variants);
+
         Ok(rateof_evaluated_haplotypes > threshold_considered_variants)
     }
 }
@@ -583,7 +578,6 @@ pub fn linear_program(
         model = model.with(constraint!(t_var >= c.clone()));
         model = model.with(constraint!(t_var >= -c.clone()));
     }
-    // dbg!(&constraints);
 
     //solve the problem with the default solver, i.e. coin_cbc
     let solution = model.solve().unwrap();
@@ -602,7 +596,6 @@ pub fn linear_program(
     println!("sum = {}", solution.eval(sum_tvars));
 
     //plot the best result
-    // dbg!(&best_variables.len());
     let candidate_matrix_values: Vec<(Vec<VariantStatus>, BitVec)> =
         candidate_matrix.values().cloned().collect();
     plot_prediction(

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -37,7 +37,7 @@ pub struct Caller {
     common_variants: bool,
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
-    extend_haplotypes:bool,
+    extend_haplotypes: bool,
     threshold_equivalence_class: usize,
     num_extend_haplotypes: i64,
 }
@@ -80,7 +80,6 @@ impl Caller {
 
             let (_, haplotype_matrix) = filtered_haplotype_variants.iter().next().unwrap();
             let haplotypes: Vec<Haplotype> = haplotype_matrix.keys().cloned().collect();
-            dbg!(&haplotypes);
 
             //check if common_variants is true, if yes use only common variants both for lp and model
             if self.common_variants {
@@ -92,9 +91,6 @@ impl Caller {
                 let filtered_haplotype_variants =
                     filtered_haplotype_variants.filter_haplotype_variants(&common_variants)?;
                 let variant_calls = variant_calls.filter_variant_calls(&common_variants)?;
-                dbg!(&common_variants);
-                dbg!(&filtered_haplotype_variants);
-                dbg!(&variant_calls);
             }
             //find the haplotypes to prioritize
             let candidate_matrix = CandidateMatrix::new(&filtered_haplotype_variants).unwrap();
@@ -114,12 +110,10 @@ impl Caller {
             //take only haplotypes that are found by lp
             let filtered_haplotype_variants = filtered_haplotype_variants
                 .find_plausible_haplotypes(&variant_calls, &lp_haplotypes)?; //fix: find_plausible haplotypes should only contain the list of "haplotypes" given as parameter
-            dbg!(&filtered_haplotype_variants);
 
             //make sure lp_haplotypes sorted the same as in filtered_haplotype_variants
             let (_, haplotype_matrix) = filtered_haplotype_variants.iter().next().unwrap();
             let final_haplotypes: Vec<Haplotype> = haplotype_matrix.keys().cloned().collect();
-            dbg!(&final_haplotypes);
 
             //construct candidate matrix
             let candidate_matrix = CandidateMatrix::new(&filtered_haplotype_variants).unwrap();
@@ -132,7 +126,6 @@ impl Caller {
                     &self.outcsv.clone(),
                 )
                 .unwrap();
-            dbg!(&eq_graph);
 
             //1-) model computation for chosen prior
             let prior = PriorTypes::from_str(&self.prior).unwrap();
@@ -156,13 +149,7 @@ impl Caller {
                 &data,
             );
             let mut event_posteriors = computed_model.event_posteriors();
-            // for (fractions,prob) in event_posteriors {
-            //     let best_fractions = fractions
-            //         .iter()
-            //         .map(|f| NotNan::into_inner(*f))
-            //         .collect::<Vec<f64>>();
-            //     dbg!(&best_fractions);
-            // }
+
             let (best_fractions, _) = event_posteriors.next().unwrap();
 
             //Step 2: plot the final solution
@@ -338,7 +325,6 @@ impl Caller {
             .for_each(|((allele, _c), g_group)| {
                 g_to_alleles.insert(allele.clone(), g_group.to_string());
             });
-        dbg!(&g_to_alleles);
         Ok(g_to_alleles)
     }
 }
@@ -349,7 +335,6 @@ fn convert_to_two_field(
     event_posteriors: &Vec<(HaplotypeFractions, LogProb)>,
     haplotypes: &Vec<Haplotype>,
 ) -> Result<(Vec<Haplotype>, Vec<(HaplotypeFractions, LogProb)>)> {
-    // dbg!(&event_posteriors);
     let mut event_posteriors_map: Vec<(BTreeMap<Haplotype, NotNan<f64>>, LogProb)> = Vec::new();
     dbg!(&event_posteriors);
     for (fractions, logprob) in event_posteriors.iter() {
@@ -386,7 +371,6 @@ fn convert_to_two_field(
     //last, create a map for haplotype-fractions to logprob,
     //in order to sum all logprobs belonging to same haplotype-fractions
     let mut hf_to_logprob: BTreeMap<BTreeMap<Haplotype, NotNan<f64>>, LogProb> = BTreeMap::new();
-    // dbg!(&event_posteriors_map);
     for (hf, logprob) in event_posteriors_map.iter() {
         if hf_to_logprob.contains_key(&hf) {
             let new_logprob = LogProb::ln_sum_exp(&vec![hf_to_logprob[&hf].clone(), *logprob]);
@@ -395,7 +379,6 @@ fn convert_to_two_field(
             hf_to_logprob.insert(hf.clone(), logprob.clone());
         }
     }
-    // dbg!(&hf_to_logprob);
     //logprob doesn't implement Ord, so, convert the map to a vector of tuples starting with logprob
     let mut logprob_and_hf = Vec::new();
     for (hf, logprob) in hf_to_logprob.iter() {

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -37,6 +37,7 @@ pub struct Caller {
     common_variants: bool,
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
+    extend_haplotypes:bool,
     threshold_equivalence_class: usize,
     num_extend_haplotypes: i64,
 }
@@ -105,6 +106,7 @@ impl Caller {
                 &haplotypes,
                 &variant_calls,
                 self.lp_cutoff,
+                self.extend_haplotypes,
                 self.num_extend_haplotypes,
             )?;
             dbg!(&lp_haplotypes);

--- a/src/calling/haplotypes/virus.rs
+++ b/src/calling/haplotypes/virus.rs
@@ -27,6 +27,7 @@ pub struct Caller {
     prior: String,
     lp_cutoff: f64,
     enable_equivalence_class_constraint: bool,
+    extend_haplotypes: bool,
     threshold_considered_variants: f64,
     threshold_equivalence_class: usize,
     num_extend_haplotypes: i64,
@@ -80,6 +81,7 @@ impl Caller {
                     &haplotypes,
                     &variant_calls,
                     self.lp_cutoff,
+                    self.extend_haplotypes,
                     self.num_extend_haplotypes,
                 )?;
                 dbg!(&lp_haplotypes);

--- a/src/calling/haplotypes/virus.rs
+++ b/src/calling/haplotypes/virus.rs
@@ -69,7 +69,6 @@ impl Caller {
 
                 let (_, haplotype_matrix) = filtered_haplotype_variants.iter().next().unwrap();
                 let haplotypes: Vec<Haplotype> = haplotype_matrix.keys().cloned().collect();
-                // dbg!(&haplotypes);
 
                 //find the haplotypes to prioritize
                 let candidate_matrix = CandidateMatrix::new(&filtered_haplotype_variants).unwrap();
@@ -84,17 +83,14 @@ impl Caller {
                     self.extend_haplotypes,
                     self.num_extend_haplotypes,
                 )?;
-                dbg!(&lp_haplotypes);
 
                 //take only haplotypes that are found by lp
                 let lp_haplotype_variants = filtered_haplotype_variants
                     .find_plausible_haplotypes(&variant_calls, &lp_haplotypes)?; //fix: find_plausible haplotypes should only contain the list of "haplotypes" given as parameter
-                // dbg!(&lp_haplotype_variants);
 
                 //make sure lp_haplotypes sorted the same as in haplotype_variants
                 let (_, haplotype_matrix) = lp_haplotype_variants.iter().next().unwrap();
                 let final_haplotypes: Vec<Haplotype> = haplotype_matrix.keys().cloned().collect();
-                // dbg!(&final_haplotypes);
 
                 //construct candidate matrix
                 let candidate_matrix = CandidateMatrix::new(&lp_haplotype_variants).unwrap();
@@ -107,7 +103,6 @@ impl Caller {
                         &self.outcsv.clone(),
                     )
                     .unwrap();
-                // dbg!(&eq_graph);
 
                 //1-) model computation for chosen prior
                 let prior = PriorTypes::from_str(&self.prior).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,11 @@ pub enum CallKind {
         enable_equivalence_class_constraint: bool,
         #[structopt(
             long,
+            help = "Enable extension of haplotypes that are computed with linear program."
+        )]
+        extend_haplotypes: bool,
+        #[structopt(
+            long,
             default_value = "1",
             help = "Threshold for assigning equivalence classes."
         )]
@@ -270,6 +275,11 @@ pub enum CallKind {
             help = "Enable equivalence based constrain during model exploration."
         )]
         enable_equivalence_class_constraint: bool,
+        #[structopt(
+            long,
+            help = "Enable extension of haplotypes that are computed with linear program."
+        )]
+        extend_haplotypes: bool,
         #[structopt(
             default_value = "0.5",
             help = "Percent threshold for evaluated variants."
@@ -374,6 +384,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 common_variants,
                 lp_cutoff,
                 enable_equivalence_class_constraint,
+                extend_haplotypes,
                 threshold_equivalence_class,
                 num_extend_haplotypes,
             } => {
@@ -388,6 +399,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .common_variants(common_variants)
                     .lp_cutoff(lp_cutoff)
                     .enable_equivalence_class_constraint(enable_equivalence_class_constraint)
+                    .extend_haplotypes(extend_haplotypes)
                     .threshold_equivalence_class(threshold_equivalence_class)
                     .num_extend_haplotypes(num_extend_haplotypes)
                     .build()
@@ -402,6 +414,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 prior,
                 lp_cutoff,
                 enable_equivalence_class_constraint,
+                extend_haplotypes,
                 threshold_equivalence_class,
                 threshold_considered_variants,
                 num_extend_haplotypes,
@@ -413,6 +426,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .prior(prior)
                     .lp_cutoff(lp_cutoff)
                     .enable_equivalence_class_constraint(enable_equivalence_class_constraint)
+                    .extend_haplotypes(extend_haplotypes)
                     .threshold_equivalence_class(threshold_equivalence_class)
                     .threshold_considered_variants(threshold_considered_variants)
                     .num_extend_haplotypes(num_extend_haplotypes)

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,9 +56,6 @@ impl Marginal {
                             .collect::<Vec<&str>>();
                         haplotype_group = Haplotype(splitted[0].to_owned() + &":" + splitted[1]);
                     } else if self.application == "virus".to_string() {
-                        let _splitted = &self.haplotypes[haplotype_index]
-                            .split(':')
-                            .collect::<Vec<&str>>();
                         haplotype_group = current_haplotype.clone();
                     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -16,6 +16,7 @@ fn check_haplotype_fractions_5050() {
         .prior("diploid".to_string())
         .lp_cutoff(0.01)
         .threshold_equivalence_class(1)
+        .extend_haplotypes(true)
         .num_extend_haplotypes(3)
         .build()
         .unwrap()


### PR DESCRIPTION
Before, during equivalence class creation, viruses also had to undergo a haplotype group check, however they don't have such groups as HLA haplotypes (first two fields) do. Further, extension of haplotype list now requires a flag to be set.