### PR TITLE
fix: fix threshold for considered variants to long argument and lower threshold

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -158,7 +158,7 @@ impl VariantCalls {
 
         let rateof_evaluated_haplotypes: f64 =
             variants_haplotype_calls.len() as f64 / variants_haplotype_variants.len() as f64;
-
+        dbg!(&variants_haplotype_calls.len(), variants_haplotype_variants.len(), &rateof_evaluated_haplotypes);
         Ok(rateof_evaluated_haplotypes > threshold_considered_variants)
     }
 }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -158,7 +158,6 @@ impl VariantCalls {
 
         let rateof_evaluated_haplotypes: f64 =
             variants_haplotype_calls.len() as f64 / variants_haplotype_variants.len() as f64;
-        dbg!(&variants_haplotype_calls.len(), variants_haplotype_variants.len(), &rateof_evaluated_haplotypes);
         Ok(rateof_evaluated_haplotypes > threshold_considered_variants)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,7 +282,7 @@ pub enum CallKind {
         extend_haplotypes: bool,
         #[structopt(
             long,
-            default_value = "0.05",
+            default_value = "0.35",
             help = "Percent threshold for evaluated variants."
         )]
         threshold_considered_variants: f64,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -281,7 +281,8 @@ pub enum CallKind {
         )]
         extend_haplotypes: bool,
         #[structopt(
-            default_value = "0.5",
+            long,
+            default_value = "0.05",
             help = "Percent threshold for evaluated variants."
         )]
         threshold_considered_variants: f64,


### PR DESCRIPTION
The long argument for `--threshold-considered-variants` has to be fixed to enable usage. Also, before we used Nextclade namings and the default value 0.5 made sense. Now we use pango lineages for candidate variant generation and we have around 5000~ variants in total.