### PR TITLE
fix: handle allele name parsing from xml with and without HLA prefix

### DIFF
--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -262,16 +262,21 @@ impl Caller {
                 Ok(Event::Eof) => break,
                 Ok(Event::Start(e)) => match e.name().as_ref() {
                     b"allele" => {
-                        alleles.push(
-                            e.attributes()
-                                .map(|a| String::from_utf8(a.unwrap().value.to_vec()))
-                                .collect::<Vec<_>>()[1]
-                                .as_ref()
-                                .unwrap()
-                                .split("-") //"HLA-" don't take the HLA prefix
-                                .collect::<Vec<&str>>()[1]
-                                .to_string(),
-                        ); //allele_name is held in index 1, note: don't use expanded_name.
+                        let allele_name = e
+                            .attributes()
+                            .map(|a| String::from_utf8(a.unwrap().value.to_vec()))
+                            .collect::<Vec<_>>()[1]
+                            .clone()
+                            .unwrap();
+                        let mut allele_name_push = "".to_string();
+                        //allele names starting with HLA contain '-' however, some aleles e.g. MICA do not contain it.
+                        if allele_name.contains(&"-") {
+                            allele_name_push =
+                                allele_name.split("-").collect::<Vec<&str>>()[1].to_string()
+                        } else {
+                            allele_name_push = allele_name.clone()
+                        }
+                        alleles.push(allele_name_push); //allele_name is held in index 1, note: don't use expanded_name.
                         names_indices.push(counter.clone());
                         counter += 1;
                     }


### PR DESCRIPTION
Some XML files from IPD-IMGT/HLA database contain allele names not starting with "HLA". An example that was causing error (note the MICA- allele name):

`<allele id="HLA01013" name="MICA*001:01" dateassigned="1998-10-10">`

and an example for the expected line before the fix:

`<allele id="HLA36872" name="HLA-DRB1*13:335" dateassigned="2022-12-21">`
