### PR TITLE
fix: fix return of invalid probabilities that are returned via linear interpolation

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -53,15 +53,8 @@ impl AlleleFreqDist {
             let y_0_prob = y_0.exp();
             let y_1_prob = y_1.exp();
             let density = NotNan::new(y_0_prob).unwrap()
-                + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
-                                                                         //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
-                                                                         //to avoid another floatisnan error, we have to be sure to return only probs that are certainly greater than 0.0 (0.000...)
-                                                                         //otherwise it should return zero probability, but in log space. (not 1 with ln_one() because density=0.0 means the probability is impossible.)
-            if density > NotNan::new(0.0).unwrap() {
-                Some(LogProb::from(Prob(NotNan::into_inner(density))))
-            } else {
-                Some(LogProb::ln_zero())
-            }
+                + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0);
+            Some(LogProb::from(Prob(NotNan::into_inner(density))))
         }
     }
 }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -55,8 +55,8 @@ impl AlleleFreqDist {
             let density = NotNan::new(y_0_prob).unwrap()
                 + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
                                                                          //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
-            //to avoid another floatisnan error, we have to be sure to return only probs that are certainly greater than 0.0 (0.000...)
-            //otherwise it should return zero probability, but in log space. (not 1 with ln_one() because density=0.0 means the probability is impossible.)
+                                                                         //to avoid another floatisnan error, we have to be sure to return only probs that are certainly greater than 0.0 (0.000...)
+                                                                         //otherwise it should return zero probability, but in log space. (not 1 with ln_one() because density=0.0 means the probability is impossible.)
             if density > NotNan::new(0.0).unwrap() {
                 Some(LogProb::from(Prob(NotNan::into_inner(density))))
             } else {

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -55,10 +55,12 @@ impl AlleleFreqDist {
             let density = NotNan::new(y_0_prob).unwrap()
                 + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0); //calculation of density for given vaf by linear interpolation
                                                                          //handle the case where density has 0 probability, which results in panicking with "FloatIsNan" error.
-            if density == NotNan::new(0.0).unwrap() {
-                Some(LogProb::ln_one())
-            } else {
+            //to avoid another floatisnan error, we have to be sure to return only probs that are certainly greater than 0.0 (0.000...)
+            //otherwise it should return zero probability, but in log space. (not 1 with ln_one() because density=0.0 means the probability is impossible.)
+            if density > NotNan::new(0.0).unwrap() {
                 Some(LogProb::from(Prob(NotNan::into_inner(density))))
+            } else {
+                Some(LogProb::ln_zero())
             }
         }
     }


### PR DESCRIPTION
Before some samples resulted in a FloatIsNan error that originates from the event posteriors computation. This is probably a numerical issue and returning only probabilities greater than 0.0 fixes the problem. However, I'm not exactly sure how the fix differs from the previous version of the code.
