### PR TITLE
fix: fix subtraction in log space

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -47,16 +47,30 @@ pub struct AlleleFreqDist(#[deref] BTreeMap<AlleleFreq, LogProb>);
 impl AlleleFreqDist {
     pub fn vaf_query(&self, vaf: &AlleleFreq) -> Option<LogProb> {
         if self.contains_key(&vaf) {
-            Some(*self.get(&vaf).unwrap())
-        } else {
+            return Some(*self.get(&vaf).unwrap());
+        }
+        else {
             let (x_0, y_0) = self.range(..vaf).next_back().unwrap();
             let (x_1, y_1) = self.range(vaf..).next().unwrap();
-            // METHOD: we perform linear interpolation on the plain probability scale
-            let y_0_prob = y_0.exp();
-            let y_1_prob = y_1.exp();
-            let density = NotNan::new(y_0_prob).unwrap()
-                + (*vaf - *x_0) * (y_1_prob - y_0_prob) / (*x_1 - *x_0);
-            Some(LogProb::from(Prob(NotNan::into_inner(density))))
+    
+            // If y_0 == y_1, what to do?
+            // if y_0 == y_1 {
+            //     return Some(*y_0);
+            // }
+            //calculate the proportion (vaf - x_0) / (x_1 - x_0) in linear space
+            let fraction = (*vaf - *x_0) / (*x_1 - *x_0);
+    
+            //ensure we interpolate in the right direction
+            let (smaller, larger) = if y_0 < y_1 { (y_0, y_1) } else { (y_1, y_0) };
+    
+            //take log difference (always positive) and subtract from each other
+            let log_diff = larger.ln_sub_exp(*smaller).exp();
+    
+            //interpolated probability in linear space again
+            let interpolated_prob = NotNan::new(smaller.exp()).unwrap() + fraction * log_diff;
+    
+            //convert back to LogProb
+            Some(LogProb::from(Prob(NotNan::into_inner(interpolated_prob))))
         }
     }
 }

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -48,27 +48,26 @@ impl AlleleFreqDist {
     pub fn vaf_query(&self, vaf: &AlleleFreq) -> Option<LogProb> {
         if self.contains_key(&vaf) {
             return Some(*self.get(&vaf).unwrap());
-        }
-        else {
+        } else {
             let (x_0, y_0) = self.range(..vaf).next_back().unwrap();
             let (x_1, y_1) = self.range(vaf..).next().unwrap();
-    
+
             // If y_0 == y_1, what to do?
             // if y_0 == y_1 {
             //     return Some(*y_0);
             // }
             //calculate the proportion (vaf - x_0) / (x_1 - x_0) in linear space
             let fraction = (*vaf - *x_0) / (*x_1 - *x_0);
-    
+
             //ensure we interpolate in the right direction
             let (smaller, larger) = if y_0 < y_1 { (y_0, y_1) } else { (y_1, y_0) };
-    
+
             //take log difference (always positive) and subtract from each other
             let log_diff = larger.ln_sub_exp(*smaller).exp();
-    
+
             //interpolated probability in linear space again
             let interpolated_prob = NotNan::new(smaller.exp()).unwrap() + fraction * log_diff;
-    
+
             //convert back to LogProb
             Some(LogProb::from(Prob(NotNan::into_inner(interpolated_prob))))
         }


### PR DESCRIPTION
This PR fixes the FloatIsNan error that comes from calling event_posteriors(), but arises numerical instability in vaf_query() function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation for probability estimates during data queries, ensuring more consistent and accurate results.
- **Refactor**
	- Streamlined the interpolation process for probability values, enhancing overall reliability and handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->