### PR TITLE
fix: remove unnecessary G from the outputted name and handle case where there is no g group field for the allele in the xml file and handle haplotypes that do not have direct match with the names in the xml

### DIFF
--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -166,26 +166,29 @@ impl Caller {
             //this is because we only use 3-field resolution of the haplotypes. This means, some haplotypes can
             // directly match, e.g. 24:436 while some e.g. A*24:03:01 have longer names in the xml.
             for haplotype in &all_haplotypes {
-                    let mut found_match = false;
-                
-                    for (allele, g_group) in &allele_to_g_groups {
-                        if allele == &haplotype.to_string() || allele.starts_with(&haplotype.to_string()) {
-                            if g_group == "None" { //in case the allele has "None" in the g group field in the xml.
-                                final_haplotypes_converted.push(haplotype.clone());
-                            } else {
-                                final_haplotypes_converted.push(Haplotype(g_group.to_string()));
-                            }
-                            found_match = true;
-                            break; 
+                let mut found_match = false;
+
+                for (allele, g_group) in &allele_to_g_groups {
+                    if allele == &haplotype.to_string()
+                        || allele.starts_with(&haplotype.to_string())
+                    {
+                        if g_group == "None" {
+                            //in case the allele has "None" in the g group field in the xml.
+                            final_haplotypes_converted.push(haplotype.clone());
+                        } else {
+                            final_haplotypes_converted.push(Haplotype(g_group.to_string()));
                         }
-                    }
-                
-                    if !found_match {
-                        //in case the allele does not have a corresponding g group field in the xml.
-                        final_haplotypes_converted.push(Haplotype(haplotype.to_string()));
+                        found_match = true;
+                        break;
                     }
                 }
-                
+
+                if !found_match {
+                    //in case the allele does not have a corresponding g group field in the xml.
+                    final_haplotypes_converted.push(Haplotype(haplotype.to_string()));
+                }
+            }
+
             dbg!(&final_haplotypes_converted);
             haplotypes::write_results(
                 &converted_name,

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -158,20 +158,28 @@ impl Caller {
             let mut converted_name = PathBuf::from(&self.outcsv.parent().unwrap());
             converted_name.push("G_groups.csv");
             let allele_to_g_groups = self.convert_to_g().unwrap();
+            dbg!(&allele_to_g_groups);
+            dbg!(&all_haplotypes);
             let mut final_haplotypes_converted: Vec<Haplotype> = Vec::new();
             all_haplotypes.iter().for_each(|haplotype| {
                 allele_to_g_groups.iter().for_each(|(allele, g_group)| {
-                    if allele == &haplotype.to_string() {
-                        if g_group == "None" {
+                    //the haplotype can either be found with the same name in the xml file or it can start with it.
+                    //this is because we only use 3-field resolution of the haplotypes. This means, some haplotypes can
+                    // directly match, e.g. 24:436 while some e.g. A*24:03:01 have longer names in the xml.
+                    if allele == &haplotype.to_string() || allele.starts_with(&haplotype.to_string()) {
+                        if g_group == "None" { //in case the allele has "None" in the g group field in the xml.
                             final_haplotypes_converted.push(haplotype.clone());
                         } else {
                             final_haplotypes_converted
-                                .push(Haplotype(g_group.to_string() + &"G".to_string()));
+                                .push(Haplotype(g_group.to_string()));
                         }
+                    } else { //in case the allele does not have a corresponding g group field in the xml.
+                        final_haplotypes_converted
+                            .push(Haplotype(haplotype.to_string()));
                     }
                 });
             });
-
+            dbg!(&final_haplotypes_converted);
             haplotypes::write_results(
                 &converted_name,
                 &data,

--- a/src/calling/haplotypes/hla.rs
+++ b/src/calling/haplotypes/hla.rs
@@ -161,24 +161,31 @@ impl Caller {
             dbg!(&allele_to_g_groups);
             dbg!(&all_haplotypes);
             let mut final_haplotypes_converted: Vec<Haplotype> = Vec::new();
-            all_haplotypes.iter().for_each(|haplotype| {
-                allele_to_g_groups.iter().for_each(|(allele, g_group)| {
-                    //the haplotype can either be found with the same name in the xml file or it can start with it.
-                    //this is because we only use 3-field resolution of the haplotypes. This means, some haplotypes can
-                    // directly match, e.g. 24:436 while some e.g. A*24:03:01 have longer names in the xml.
-                    if allele == &haplotype.to_string() || allele.starts_with(&haplotype.to_string()) {
-                        if g_group == "None" { //in case the allele has "None" in the g group field in the xml.
-                            final_haplotypes_converted.push(haplotype.clone());
-                        } else {
-                            final_haplotypes_converted
-                                .push(Haplotype(g_group.to_string()));
+
+            //the haplotype can either be found with the same name in the xml file or it can start with it.
+            //this is because we only use 3-field resolution of the haplotypes. This means, some haplotypes can
+            // directly match, e.g. 24:436 while some e.g. A*24:03:01 have longer names in the xml.
+            for haplotype in &all_haplotypes {
+                    let mut found_match = false;
+                
+                    for (allele, g_group) in &allele_to_g_groups {
+                        if allele == &haplotype.to_string() || allele.starts_with(&haplotype.to_string()) {
+                            if g_group == "None" { //in case the allele has "None" in the g group field in the xml.
+                                final_haplotypes_converted.push(haplotype.clone());
+                            } else {
+                                final_haplotypes_converted.push(Haplotype(g_group.to_string()));
+                            }
+                            found_match = true;
+                            break; 
                         }
-                    } else { //in case the allele does not have a corresponding g group field in the xml.
-                        final_haplotypes_converted
-                            .push(Haplotype(haplotype.to_string()));
                     }
-                });
-            });
+                
+                    if !found_match {
+                        //in case the allele does not have a corresponding g group field in the xml.
+                        final_haplotypes_converted.push(Haplotype(haplotype.to_string()));
+                    }
+                }
+                
             dbg!(&final_haplotypes_converted);
             haplotypes::write_results(
                 &converted_name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced haplotype matching to support partial allele name matches for improved compatibility.
  - Ensured all haplotypes are included in the output, either as their G group or original string.

- **Other**
  - Added debug output for mapping and conversion processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->