### PR TITLE
feat: replace bubble plot with tick marks and use normal probs instead of logprobs in the final solution plot

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -818,7 +818,7 @@ pub fn plot_prediction(
                                     plot_data_dataset_afd.push(DatasetAfd {
                                         variant_change: var_change.to_string(),
                                         allele_freq: *allele_freq,
-                                        probability: prob.exp(),
+                                        probability: f64::from(prob.exp()),
                                     })
                                 }
                                 b_check = true;

--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -818,7 +818,7 @@ pub fn plot_prediction(
                                     plot_data_dataset_afd.push(DatasetAfd {
                                         variant_change: var_change.to_string(),
                                         allele_freq: *allele_freq,
-                                        probability: f64::from(*prob),
+                                        probability: prob.exp(),
                                     })
                                 }
                                 b_check = true;
@@ -845,7 +845,7 @@ pub fn plot_prediction(
                                         plot_data_dataset_afd.push(DatasetAfd {
                                             variant_change: var_change.to_string(),
                                             allele_freq: *allele_freq,
-                                            probability: f64::from(*prob),
+                                            probability: f64::from(prob.exp()),
                                         })
                                     }
                                 }

--- a/templates/final_prediction.json
+++ b/templates/final_prediction.json
@@ -84,7 +84,7 @@
     },
     {
       "data": {"name": "allele_frequency_distribution"},
-      "mark": {"type": "circle", "tooltip": true},
+      "mark": {"type": "tick", "tooltip": true},
       "encoding": {
         "x": {
           "field": "variant_change",
@@ -97,19 +97,9 @@
           "type": "quantitative",
           "title": "Allele frequency",
           "axis": {"labelFontSize": 12, "titleFontSize": 16}
-        },
-        "color": {
-          "field": "probability",
-          "type": "quantitative",
-          "legend": {"title": null}
-        },
-        "size": {
-          "field": "probability",
-          "type": "quantitative",
-          "legend": {"title": null}
         }
       }
-    }
+    }    
   ],
   "resolve": {
   "scale": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Probability values in visualizations are now displayed on a linear scale instead of a log scale, improving interpretability.

- **Style**
	- Updated the graphical representation of allele frequency distribution from circles to ticks for clearer visualization.
	- Removed color and size encoding from the allele frequency distribution plot, simplifying the display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->