### PR TITLE
feat: add pinned feature to template for first 4 columns of lp datavzrd report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "datavzrd"
-version = "2.54.0"
+version = "2.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1089dc8119fb88e3bf16ee9195162a56ce3456e1acdc31715c2a86a49e5890e8"
+checksum = "c21ab0ea8d1dbd6900b09efc5dd56b472803a6291e898db1f18faf02ac76347f"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "3"
 futures = "0.3" # for our async / await blocks
 seq_io = "0.3.2"
 petgraph = "0.6.4"
-datavzrd = "2.55.0"
+datavzrd = "2.56.0"
 serde_yaml = "0.9"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "3"
 futures = "0.3" # for our async / await blocks
 seq_io = "0.3.2"
 petgraph = "0.6.4"
-datavzrd = "2.56.0"
+datavzrd = "2.55.0"
 serde_yaml = "0.9"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "3"
 futures = "0.3" # for our async / await blocks
 seq_io = "0.3.2"
 petgraph = "0.6.4"
-datavzrd = "2.54.0"
+datavzrd = "2.55.0"
 serde_yaml = "0.9"
 
 [profile.release]

--- a/templates/datavzrd_config.yaml
+++ b/templates/datavzrd_config.yaml
@@ -14,6 +14,7 @@ views:
     render-table:
       columns:
         sum_of_fractions:
+          display-mode: pinned
           custom-plot:
             data: function(value, row) { return JSON.parse(value); }
             spec: |
@@ -66,6 +67,10 @@ views:
                   ],
                   "height": 20
                 }
+        vaf:
+          display-mode: pinned        
+        prediction_error:
+          display-mode: pinned
         regex('A.+'):
           spell:
             url: v1.2.2/logic/boolean
@@ -73,5 +78,6 @@ views:
               true_value: "1"
               false_value: "0"
         variant:
+          display-mode: pinned
           spell:
             url: v1.3.0/med/genomic-coordinates


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Columns `sum_of_fractions`, `vaf`, `prediction_error`, and `variant` are now pinned in the solutions view, ensuring they remain visible when scrolling horizontally.

- **Chores**
  - Updated the `datavzrd` dependency to version 2.56.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->