### PR TITLE
fix: update rust bio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ fern = "0.6"
 statrs = "0.15"
 anyhow = "1.0"
 derefable = "0.1"
-bio = { git="https://github.com/huzuner/rust-bio.git", branch = "update-lazy-static"}
+bio = "2.3.0"
 derive_deref = "1.1.1"
 assert_approx_eq = "1.1.0"
 ndarray = "0.15.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bio library dependency to use the official stable release version 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->