### PR TITLE
feat: implement optional parameter for outputting bam file produced with alleles to reference genome alignment and configure virus output to the given filepath instead of the previous candidates.vcf

### DIFF
--- a/src/candidates/hla.rs
+++ b/src/candidates/hla.rs
@@ -35,7 +35,7 @@ pub struct Caller {
     output: PathBuf,
     threads: String,
     output_bcf: bool,
-    output_bam: bool
+    output_bam: bool,
 }
 impl Caller {
     pub fn call(&self) -> Result<()> {
@@ -59,11 +59,8 @@ impl Caller {
 
         //find variants from cigar
         let bam_path: &PathBuf = &self.output.join("alleles_alignment_sorted.bam");
-        let (mut genotype_df, mut loci_df) = find_variants_from_cigar(
-            &self.genome,
-            bam_path,
-        )
-        .unwrap();
+        let (mut genotype_df, mut loci_df) =
+            find_variants_from_cigar(&self.genome, bam_path).unwrap();
 
         //Unconfirmed alleles are removed from both dataframes
         unconfirmed_alleles.iter().for_each(|unconf_allele| {

--- a/src/candidates/virus/generic.rs
+++ b/src/candidates/virus/generic.rs
@@ -22,7 +22,7 @@ pub struct Caller {
     output: PathBuf,
     threads: String,
     output_bcf: bool,
-    output_bam: bool
+    output_bam: bool,
 }
 impl Caller {
     pub fn call(&mut self) -> Result<()> {
@@ -37,17 +37,13 @@ impl Caller {
         )?;
 
         //create path to the bam file
-        let bam_path: &PathBuf = &self.output.with_file_name("viruses_alignment_sorted.bam"); 
+        let bam_path: &PathBuf = &self.output.with_file_name("viruses_alignment_sorted.bam");
 
         //find variants from cigar
-        let (genotype_df, loci_df) = find_variants_from_cigar(
-            &self.genome,
-            &bam_path,
-        )
-        .unwrap();
+        let (genotype_df, loci_df) = find_variants_from_cigar(&self.genome, &bam_path).unwrap();
 
         //write locus-wise vcf files.
-        write_to_vcf( &self.output, genotype_df, loci_df, self.output_bcf)?;
+        write_to_vcf(&self.output, genotype_df, loci_df, self.output_bcf)?;
 
         //remove alignment file based on output_bam
         if !self.output_bam {

--- a/src/candidates/virus/generic.rs
+++ b/src/candidates/virus/generic.rs
@@ -22,6 +22,7 @@ pub struct Caller {
     output: PathBuf,
     threads: String,
     output_bcf: bool,
+    output_bam: bool
 }
 impl Caller {
     pub fn call(&mut self) -> Result<()> {
@@ -35,28 +36,34 @@ impl Caller {
             &self.output,
         )?;
 
+        //create path to the bam file
+        let bam_path: &PathBuf = &self.output.with_file_name("viruses_alignment_sorted.bam"); 
+
         //find variants from cigar
         let (genotype_df, loci_df) = find_variants_from_cigar(
             &self.genome,
-            &self.output.join("viruses_alignment_sorted.bam"),
+            &bam_path,
         )
         .unwrap();
 
         //write locus-wise vcf files.
-        write_to_vcf(&self.output, genotype_df, loci_df, self.output_bcf)?;
+        write_to_vcf( &self.output, genotype_df, loci_df, self.output_bcf)?;
+
+        //remove alignment file based on output_bam
+        if !self.output_bam {
+            std::fs::remove_file(bam_path)?;
+        }
 
         Ok(())
     }
 }
 
 pub fn write_to_vcf(
-    outdir: &PathBuf,
+    output_path: &PathBuf,
     variant_table: DataFrame,
     loci_table: DataFrame,
     output_bcf: bool,
 ) -> Result<()> {
-    // dbg!(&variant_table);
-    //Create VCF header
     let mut header = Header::new();
 
     //get contig name of the reference
@@ -88,14 +95,7 @@ pub fn write_to_vcf(
     // let outdir: &_ = outdir;
 
     //create VCF/BCF Writer
-    let output_path = format!(
-        "{}.{}",
-        outdir.join("candidates").display(),
-        if output_bcf { "bcf" } else { "vcf" }
-    );
-
     let format = if output_bcf { Format::Bcf } else { Format::Vcf };
-
     let mut writer = Writer::from_path(&output_path, &header, true, format)
         .expect("Failed to create VCF/BCF writer");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,9 +161,9 @@ pub enum CandidatesKind {
         // allele_freq: PathBuf,
         #[structopt(
             long,
-            help = "Folder to store quality control plots for the inference of a CDF from Kallisto bootstraps for each haplotype of interest."
+            help = "Folder to store candidate variants for each loci. Currently, only A, B, C and DQB1 are supported."
         )]
-        output: Option<PathBuf>,
+        output: PathBuf,
         #[structopt(
             default_value = "1",
             long = "threads",
@@ -175,6 +175,11 @@ pub enum CandidatesKind {
             help = "Generate BCF output instead of the default VCF file format."
         )]
         output_bcf: bool,
+        #[structopt(
+            long,
+            help = "Output BAM containing alignment of haplotypes against the reference genome."
+        )]
+        output_bam: bool
     },
     Virus {
         #[structopt(
@@ -198,6 +203,11 @@ pub enum CandidatesKind {
             help = "Generate BCF output instead of the default VCF file format."
         )]
         output_bcf: bool,
+        #[structopt(
+            long,
+            help = "Output BAM containing alignment of haplotypes against the reference genome."
+        )]
+        output_bam: bool
     },
 }
 
@@ -396,6 +406,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 output,
                 threads,
                 output_bcf,
+                output_bam
             } => {
                 let caller = candidates::hla::CallerBuilder::default()
                     .alleles(alleles)
@@ -405,6 +416,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .output(output)
                     .threads(threads)
                     .output_bcf(output_bcf)
+                    .output_bam(output_bam)
                     .build()
                     .unwrap();
                 caller.call()?;
@@ -416,6 +428,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 output,
                 threads,
                 output_bcf,
+                output_bam
             } => {
                 let mut caller = candidates::virus::generic::CallerBuilder::default()
                     .genome(genome)
@@ -423,6 +436,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                     .output(output)
                     .threads(threads)
                     .output_bcf(output_bcf)
+                    .output_bam(output_bam)
                     .build()
                     .unwrap();
                 caller.call()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,7 +179,7 @@ pub enum CandidatesKind {
             long,
             help = "Output BAM containing alignment of haplotypes against the reference genome."
         )]
-        output_bam: bool
+        output_bam: bool,
     },
     Virus {
         #[structopt(
@@ -207,7 +207,7 @@ pub enum CandidatesKind {
             long,
             help = "Output BAM containing alignment of haplotypes against the reference genome."
         )]
-        output_bam: bool
+        output_bam: bool,
     },
 }
 
@@ -406,7 +406,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 output,
                 threads,
                 output_bcf,
-                output_bam
+                output_bam,
             } => {
                 let caller = candidates::hla::CallerBuilder::default()
                     .alleles(alleles)
@@ -428,7 +428,7 @@ pub fn run(opt: Orthanq) -> Result<()> {
                 output,
                 threads,
                 output_bcf,
-                output_bam
+                output_bam,
             } => {
                 let mut caller = candidates::virus::generic::CallerBuilder::default()
                     .genome(genome)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --output-bam flag for HLA and Virus candidate workflows to optionally keep alignment BAM files (default: BAMs are removed after processing).
- Bug Fixes
  - Ensures output directories are created automatically, improving reliability of file writing and cleanup.
  - More robust path handling for generated files.
- Documentation
  - Updated CLI help text.
- Breaking Change
  - HLA candidates now require an explicit --output directory (no longer optional).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->