### PR TITLE
fix: handle missing DP

### DIFF
--- a/src/calling/haplotypes/haplotypes.rs
+++ b/src/calling/haplotypes/haplotypes.rs
@@ -16,12 +16,12 @@ use ordered_float::NotNan;
 use good_lp::IntoAffineExpression;
 use good_lp::*;
 use good_lp::{constraint, variable, variables, Expression, ResolutionError, SolverModel};
+use rust_htslib::bcf::record::Numeric;
 use rust_htslib::bcf::{
     self,
     record::GenotypeAllele::{Phased, Unphased},
     Read,
 };
-use rust_htslib::bcf::record::Numeric;
 use std::cmp;
 use std::error::Error;
 
@@ -182,7 +182,7 @@ impl VariantCalls {
             let mut record = record_result?;
             record.unpack();
             let variant_id: i32 = String::from_utf8(record.id())?.parse()?;
-            // dbg!(&variant_id);
+
             //by default, make prob_absent and prob_present 0.0 to handle the case with NaN prob values
             let mut prob_absent = NotNan::new(0.0).unwrap();
             let mut prob_present = NotNan::new(0.0).unwrap();
@@ -198,23 +198,20 @@ impl VariantCalls {
                 prob_present =
                     NotNan::new(*Prob::from(PHREDProb(parsed_prob_present.into()))).unwrap();
             }
-            // dbg!(&prob_absent, &prob_present);
 
             //get max of prob_absent and prob_present to use for weighting in linear program
             let max_prob = cmp::max(prob_absent, prob_present);
-            // dbg!(&max_prob);
 
+            //retrieve afd string
             let afd_utf = record.format(b"AFD").string()?;
             let afd_str = std::str::from_utf8(afd_utf[0])?;
-            //handle missing DP values 
+
+            //handle missing DP values
             let dp = record.format(b"DP").integer().unwrap();
             let dp_val = dp[0][0];
             let read_depth_int = if dp_val.is_missing() { 0 } else { dp_val };
 
             //include all variants without making a difference for their depth of coverage.
-            // if read_depth[0] != &[0]
-            // // && (&prob_absent_prob <= &Prob(0.05) || &prob_absent_prob >= &Prob(0.95))
-            // {
             //because some afd strings are just "." and that throws an error while splitting below.
             let variant_id: i32 = String::from_utf8(record.id())?.parse()?;
             let af = (&*record.format(b"AF").float().unwrap()[0]).to_vec()[0];
@@ -227,7 +224,8 @@ impl VariantCalls {
                     vaf_density.insert(vaf, LogProb::from(PHREDProb(density)));
                 }
             }
-            //exxtract reference (REF), alternative (ALT), and position (POS)
+
+            //extract reference (REF), alternative (ALT), and position (POS)
             let chr_name = std::str::from_utf8(header.rid2name(record.rid().unwrap()).unwrap())?;
             let pos = record.pos() + 1; // 1-based indexing
             let ref_base = std::str::from_utf8(record.alleles()[0])?;


### PR DESCRIPTION
Some versions of Varlociraptor results in missing DP values. The latest version released on the day of PR now outputs zero DP but this PR still handles this case that can appear when an older Varlociraptor version is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of missing read depth (DP) in variant inputs: now defaults to 0 instead of failing, preventing errors and allowing analyses to proceed.
  - Enhances stability across edge-case datasets and diverse inputs with incomplete metadata.
  - No impact on results when DP is present; existing behavior remains unchanged.
  - Overall improves reliability and predictability of variant calling in scenarios with missing DP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->